### PR TITLE
Only allow sorting groups depending on the container QL

### DIFF
--- a/mods/bulkseparated.properties
+++ b/mods/bulkseparated.properties
@@ -14,3 +14,5 @@ fasterTransfer=true
 unlimitedRemove=true
 # Enable showing if a container is sorted or not
 showSortingStatus=true
+# Only sort into groups lower than the Ql of the container (e.g. 50ql bsb will have 0-10,10-20,20-30,30-40,40-50,50+ groups)
+restrictToContainerQl=false

--- a/src/main/java/org/takino/mods/BulkItemsHooks.java
+++ b/src/main/java/org/takino/mods/BulkItemsHooks.java
@@ -14,21 +14,25 @@ public class BulkItemsHooks {
     public static Item getTargetToAdd(Item bulkInventory, int templateId, int material, float quality, byte aux, int realTemplateId) {
         for (Item item : bulkInventory.getItems()) {
             if (item.getRealTemplateId() == templateId && item.getMaterial() == material && item.getAuxData() == aux && ((realTemplateId == -10 && item.getData1() == -1) || item.getData1() == realTemplateId)) {
-                float bulkQuality = item.getQualityLevel();
-                if (quality > 99.995f) {
-                    if (bulkQuality > 99.995f) return item;
-                } else if (bulkQuality < 90 && quality < 90) {
-                    double upperBoundary = Math.round((bulkQuality + 5) / 10.0) * 10.0;
-                    double lowerBoundary = Math.round((bulkQuality - 5) / 10.0) * 10.0;
-                    if (quality <= upperBoundary && quality >= lowerBoundary) {
-                        return item;
+                if (BulkItemsSeperated.restrictToContainerQl == false || bulkInventory.getQualityLevel() <= quality) {
+                    float bulkQuality = item.getQualityLevel();
+                    if (quality > 99.995f) {
+                        if (bulkQuality > 99.995f) return item;
+                    } else if (bulkQuality < 90 && quality < 90) {
+                        double upperBoundary = Math.round((bulkQuality + 5) / 10.0) * 10.0;
+                        double lowerBoundary = Math.round((bulkQuality - 5) / 10.0) * 10.0;
+                        if (quality <= upperBoundary && quality >= lowerBoundary) {
+                            return item;
+                        }
+                    } else if (quality >= 90 && bulkQuality >= 90) {
+                        double upperBoundary = Math.ceil(bulkQuality);
+                        double lowerBoundary = Math.floor(bulkQuality);
+                        if (quality <= upperBoundary && quality >= lowerBoundary) {
+                            return item;
+                        }
                     }
-                } else if (quality >= 90 && bulkQuality >= 90) {
-                    double upperBoundary = Math.ceil(bulkQuality);
-                    double lowerBoundary = Math.floor(bulkQuality);
-                    if (quality <= upperBoundary && quality >= lowerBoundary) {
-                        return item;
-                    }
+                } else {
+                    return item;
                 }
             }
         }

--- a/src/main/java/org/takino/mods/BulkItemsSeparated.java
+++ b/src/main/java/org/takino/mods/BulkItemsSeparated.java
@@ -27,6 +27,7 @@ public class BulkItemsSeparated implements WurmServerMod, PreInitable, Initable,
     public static boolean allowCrateSorting;
     public static boolean allowNonCrateSorting;
     public static boolean showSortingStatus;
+    public static boolean restrictToContainerQl;
 
     @Override
     public void configure(Properties properties) {
@@ -36,6 +37,7 @@ public class BulkItemsSeparated implements WurmServerMod, PreInitable, Initable,
         fasterTransfer = Boolean.parseBoolean(properties.getProperty("fasterTransfer", "true"));
         unlimitedRemove = Boolean.parseBoolean(properties.getProperty("unlimitedRemove", "true"));
         showSortingStatus = Boolean.parseBoolean(properties.getProperty("showSortingStatus", "true"));
+        restrictToContainerQl = Boolean.parseBoolean(properties.getProperty("restrictToContainerQl", "false"));
     }
 
     @Override


### PR DESCRIPTION
This should mean the bulk container quality matters when this flag is enabled, so in order to sort higher quality items the bulk container will need to be above those quality steps.